### PR TITLE
Support for new RegExp flags

### DIFF
--- a/base-impl/src/main/java/com/intellij/lang/javascript/JavaScript.flex
+++ b/base-impl/src/main/java/com/intellij/lang/javascript/JavaScript.flex
@@ -62,7 +62,7 @@ DOUBLE_QUOTED_LITERAL=\"([^\\\"\r\n]|{ESCAPE_SEQUENCE}|\\{CRLF})*(\"|\\)?
 ESCAPE_SEQUENCE=\\[^\r\n]
 GROUP = "[" [^\]]* "]"
 
-REGEXP_LITERAL="/"([^\*\\/\r\n]|{ESCAPE_SEQUENCE}|{GROUP})([^\\/\r\n]|{ESCAPE_SEQUENCE}|{GROUP})*("/"[gimx\u]*)?
+REGEXP_LITERAL="/"([^\*\\/\r\n]|{ESCAPE_SEQUENCE}|{GROUP})([^\\/\r\n]|{ESCAPE_SEQUENCE}|{GROUP})*("/"[dgimsuvy]*)?
 ALPHA=[:letter:]
 DIGIT=[0-9]
 XML_NAME=({ALPHA}|"_")({ALPHA}|{DIGIT}|"_"|"."|"-")*(":"({ALPHA}|"_")?({ALPHA}|{DIGIT}|"_"|"."|"-")*)?

--- a/lang-version-impl/ecmascript-impl/src/main/java/consulo/javascript/ecmascript/lang/lexer/ecmascript6.flex
+++ b/lang-version-impl/ecmascript-impl/src/main/java/consulo/javascript/ecmascript/lang/lexer/ecmascript6.flex
@@ -67,7 +67,7 @@ DOUBLE_QUOTED_LITERAL=\"([^\\\"\r\n]|{ESCAPE_SEQUENCE}|\\{CRLF})*(\"|\\)?
 ESCAPE_SEQUENCE=\\[^\r\n]
 GROUP = "[" [^\]]* "]"
 
-REGEXP_LITERAL="/"([^\*\\/\r\n]|{ESCAPE_SEQUENCE}|{GROUP})([^\\/\r\n]|{ESCAPE_SEQUENCE}|{GROUP})*("/"[gimxu]*)?
+REGEXP_LITERAL="/"([^\*\\/\r\n]|{ESCAPE_SEQUENCE}|{GROUP})([^\\/\r\n]|{ESCAPE_SEQUENCE}|{GROUP})*("/"[gimsuy]*)?
 INTERPOLATION_STRING_LITERAL="`" [^"`"]* "`"
 
 ALPHA=[:letter:]


### PR DESCRIPTION
Flag 'd', hasIndices (ES13/ES2022). Flas 's', dotAll (ES9/ES2018). Flag 'u', unicode (ES6/ES2015). Flag 'v', unicodeSets (ES13/ES2024). Flag 'y', sticky (ES6/ES2015).